### PR TITLE
partial implementation of displaying med history events on calendar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,12 @@
       "name": "client",
       "version": "0.1.0",
       "dependencies": {
+        "@fullcalendar/core": "^5.11.3",
+        "@fullcalendar/daygrid": "^5.11.3",
+        "@fullcalendar/interaction": "^5.11.3",
+        "@fullcalendar/list": "^5.11.3",
+        "@fullcalendar/react": "^5.11.2",
+        "@fullcalendar/timegrid": "^5.11.3",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
@@ -2112,6 +2118,74 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@fullcalendar/common": {
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/common/-/common-5.11.3.tgz",
+      "integrity": "sha512-welVwyfQOXQQGfDwBMSfYEPbiO1cPfUD+C7jd3ZoweJR+dSO11ddFugxIQ7dGfABAGZ63oq/+LW9FsmAJezVNg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@fullcalendar/core": {
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-5.11.3.tgz",
+      "integrity": "sha512-YUFxCvVJytUwFeXCx4J17kFMM7Ixwn9zBjVRw5NM2bMwgR6VAhSnlZc6yNQSOIy7Hj2TF0vDkO/4JNlTvxyAXw==",
+      "dependencies": {
+        "@fullcalendar/common": "~5.11.3",
+        "preact": "^10.0.5",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@fullcalendar/daygrid": {
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-5.11.3.tgz",
+      "integrity": "sha512-PCK0y80DRNCzWuC5lGpIWqCgKDvql1ah7rXql5lu+Gn2EeFj15ZQ8diMFjtNIQucEmFaNOXnR05Pgcry1n6Shg==",
+      "dependencies": {
+        "@fullcalendar/common": "~5.11.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@fullcalendar/interaction": {
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-5.11.3.tgz",
+      "integrity": "sha512-L955wkDjza62K96ndstvYs2Fd4V0kayTDpqW8W7huFG3Ox8MutpLqKAa2SCaTvcNIlWS4oexGQRiQAaJG7u47A==",
+      "dependencies": {
+        "@fullcalendar/common": "~5.11.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@fullcalendar/list": {
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/list/-/list-5.11.3.tgz",
+      "integrity": "sha512-6m9rJPzB5XfJZg+MlgVpha1cI3NUDeyV3GOmojJWZuti05NfDP4f0lzFUul8W7m1DQcjGS2UPRNE8HouA3guEA==",
+      "dependencies": {
+        "@fullcalendar/common": "~5.11.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@fullcalendar/react": {
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-5.11.2.tgz",
+      "integrity": "sha512-OnLvfV406VEQcK4QGN8xR4ro6Manp9dKE7/n9dhs19J1kKpqS1w1sIEYg1dT11njbk0Ob+TdF3cXLDFq73jUlA==",
+      "dependencies": {
+        "@fullcalendar/common": "~5.11.2",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.7.0 || ^17 || ^18",
+        "react-dom": "^16.7.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/@fullcalendar/timegrid": {
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-5.11.3.tgz",
+      "integrity": "sha512-SjIj2ZQ7nTyL1RxZkCPvNbuUQ0xHT+gfYJdUL3FT4bPjPJCxWtQ2CL8hxaeNmVozYYuy0yrGTW5Oup2+9IplbA==",
+      "dependencies": {
+        "@fullcalendar/common": "~5.11.3",
+        "@fullcalendar/daygrid": "~5.11.3",
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -13284,6 +13358,15 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "node_modules/preact": {
+      "version": "10.10.6",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.10.6.tgz",
+      "integrity": "sha512-w0mCL5vICUAZrh1DuHEdOWBjxdO62lvcO++jbzr8UhhYcTbFkpegLH9XX+7MadjTl/y0feoqwQ/zAnzkc/EGog==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -15132,9 +15215,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.14.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
-      "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
+      "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -17852,6 +17935,70 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
+      }
+    },
+    "@fullcalendar/common": {
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/common/-/common-5.11.3.tgz",
+      "integrity": "sha512-welVwyfQOXQQGfDwBMSfYEPbiO1cPfUD+C7jd3ZoweJR+dSO11ddFugxIQ7dGfABAGZ63oq/+LW9FsmAJezVNg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "@fullcalendar/core": {
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-5.11.3.tgz",
+      "integrity": "sha512-YUFxCvVJytUwFeXCx4J17kFMM7Ixwn9zBjVRw5NM2bMwgR6VAhSnlZc6yNQSOIy7Hj2TF0vDkO/4JNlTvxyAXw==",
+      "requires": {
+        "@fullcalendar/common": "~5.11.3",
+        "preact": "^10.0.5",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@fullcalendar/daygrid": {
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-5.11.3.tgz",
+      "integrity": "sha512-PCK0y80DRNCzWuC5lGpIWqCgKDvql1ah7rXql5lu+Gn2EeFj15ZQ8diMFjtNIQucEmFaNOXnR05Pgcry1n6Shg==",
+      "requires": {
+        "@fullcalendar/common": "~5.11.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@fullcalendar/interaction": {
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-5.11.3.tgz",
+      "integrity": "sha512-L955wkDjza62K96ndstvYs2Fd4V0kayTDpqW8W7huFG3Ox8MutpLqKAa2SCaTvcNIlWS4oexGQRiQAaJG7u47A==",
+      "requires": {
+        "@fullcalendar/common": "~5.11.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@fullcalendar/list": {
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/list/-/list-5.11.3.tgz",
+      "integrity": "sha512-6m9rJPzB5XfJZg+MlgVpha1cI3NUDeyV3GOmojJWZuti05NfDP4f0lzFUul8W7m1DQcjGS2UPRNE8HouA3guEA==",
+      "requires": {
+        "@fullcalendar/common": "~5.11.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@fullcalendar/react": {
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-5.11.2.tgz",
+      "integrity": "sha512-OnLvfV406VEQcK4QGN8xR4ro6Manp9dKE7/n9dhs19J1kKpqS1w1sIEYg1dT11njbk0Ob+TdF3cXLDFq73jUlA==",
+      "requires": {
+        "@fullcalendar/common": "~5.11.2",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@fullcalendar/timegrid": {
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-5.11.3.tgz",
+      "integrity": "sha512-SjIj2ZQ7nTyL1RxZkCPvNbuUQ0xHT+gfYJdUL3FT4bPjPJCxWtQ2CL8hxaeNmVozYYuy0yrGTW5Oup2+9IplbA==",
+      "requires": {
+        "@fullcalendar/common": "~5.11.3",
+        "@fullcalendar/daygrid": "~5.11.3",
+        "tslib": "^2.1.0"
       }
     },
     "@humanwhocodes/config-array": {
@@ -25798,6 +25945,11 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "preact": {
+      "version": "10.10.6",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.10.6.tgz",
+      "integrity": "sha512-w0mCL5vICUAZrh1DuHEdOWBjxdO62lvcO++jbzr8UhhYcTbFkpegLH9XX+7MadjTl/y0feoqwQ/zAnzkc/EGog=="
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -27174,9 +27326,9 @@
       }
     },
     "terser": {
-      "version": "5.14.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
-      "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
+      "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
       "requires": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fullcalendar/core": "^5.11.3",
+    "@fullcalendar/daygrid": "^5.11.3",
+    "@fullcalendar/interaction": "^5.11.3",
+    "@fullcalendar/list": "^5.11.3",
+    "@fullcalendar/react": "^5.11.2",
+    "@fullcalendar/timegrid": "^5.11.3",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,19 @@
 import { useState } from 'react';
 import Landing from './pages/Landing';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import Dashboard from './pages/Dashboard';
 import Authenticate from './components/entry/Authenticate';
+import Dashboard from './pages/Dashboard';
+import MedicationHistory from './pages/MedicationHistory';
 import Profile from './pages/Profile';
 import { Medication } from './types';
+import { History } from './types';
+import { EventInput } from '@fullcalendar/react'
 
 const App = () => {
   const [user, setUser] = useState<string>('');
   const [medications, setMedications] = useState<Medication[]>([]);
+  const [history, setHistory] = useState<History[]>([]);
+  const [events, setEvents] = useState<EventInput[]>([]);
 
   return (
     <BrowserRouter>
@@ -18,7 +23,24 @@ const App = () => {
           path='/dashboard'
           element={
             <Authenticate>
-              <Dashboard user={user} setUser={setUser} meds={medications} setMeds={setMedications} />
+              <Dashboard
+                user={user}
+                setUser={setUser}
+                meds={medications}
+                setMeds={setMedications}
+                history={history}
+                setHistory={setHistory}
+                events={events}
+                setEvents={setEvents}
+              />
+            </Authenticate>
+          }
+        />
+        <Route
+          path='/history'
+          element={
+            <Authenticate>
+              <MedicationHistory user={user} events={events} />
             </Authenticate>
           }
         />

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,0 +1,33 @@
+import FullCalendar from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import timeGridPlugin from '@fullcalendar/timegrid';
+import interactionPlugin from '@fullcalendar/interaction';
+import { CalendarData } from '../types';
+
+const Calendar = (events: CalendarData) => {
+
+  return (
+    <FullCalendar
+      plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
+      headerToolbar={{
+        start: 'prev,next today',
+        center: 'title',
+        end: 'dayGridMonth,timeGridWeek,timeGridDay'
+      }}
+      titleFormat={{
+        month: 'short',
+        year: 'numeric',
+        day: 'numeric',
+      }}
+      initialView='dayGridDay'
+      editable={true}
+      selectable={true}
+      selectMirror={true}
+      dayMaxEvents={true}
+      weekends={true}
+      initialEvents={events} // alternatively, use the `events` setting to fetch from a feed
+    />
+  )
+}
+
+export default Calendar;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -25,6 +25,20 @@ const Navbar = () => {
                 </span>
           }
           {
+            location.pathname === '/history'
+              ? <span
+                  className='cursor-default pr-8 font-bold text-white'
+                >
+                  History
+                </span>
+              : <span
+                  className='cursor-pointer pr-8 hover:text-white'
+                  onClick={() => { navigate('/history') }}
+                >
+                  History
+                </span>
+          }
+          {
             location.pathname === '/profile'
               ? <span
                   className='cursor-default pr-8 font-bold text-white'

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,30 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.fc-daygrid-more-link,
+.fc-more-link {
+  color: #2C3E50;
+}
+
+@media screen and (max-device-width: 550px) {
+  .fc-header-toolbar {
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+@media screen and (max-device-width: 413px) {
+  .fc-daygrid-more-link,
+  .fc-more-link {
+    position: absolute;
+    bottom: 2.4rem;
+  }
+}
+@media screen and (min-device-width: 414px) and (max-device-width: 550px) {
+  .fc-daygrid-more-link,
+  .fc-more-link {
+    position: absolute;
+    bottom: .5rem;
+  }
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,10 +1,48 @@
 import axios from 'axios';
 import { useEffect } from 'react';
-import { Medication, UserDataProps } from '../types';
+import { History, MedHistoryProps, Medication } from '../types';
 import MedicationList from '../components/medication/MedicationList';
 import Navbar from '../components/Navbar';
+import { EventInput } from '@fullcalendar/react';
 
 // place in helpers
+const getMedHistory = async (
+  saveHistory: (medHistory: History[]) => void,
+  saveEvents: (evtInput: EventInput[]) => void,
+  events: EventInput[],
+) => {
+  try {
+    const res = await axios.get('/user', {
+      headers: {
+        token: localStorage.getItem('token') || '',
+      }
+    });
+
+    saveHistory(res.data.user.history);
+    const historicalEvents: EventInput[] = formatHistory(res.data.user.history, events);
+    saveEvents(historicalEvents);
+  } catch (err) {
+    console.error(err);
+  }
+};
+
+const formatHistory = (history: History[], events: EventInput[]) => {
+  const historyCount = history.reduce((count: number, dayHx: History) => dayHx.medsDue.length + count, 0);
+
+  if (historyCount !== events.length) {
+    for (let i = events.length; i <= historyCount; i++) {
+      history[i]?.medsDue.forEach((med, j) => {
+        events.push({
+          id: history[i]._id + j,
+          title: med.name + (med.administered ? ': Taken' : ': Not taken'),
+          start: history[i].dateDue.toString().replace(/T.*$/, '') + `T${med.time}`,
+        });
+      })
+    }
+  }
+  return events;
+};
+
 const getMedsDue = (medsList: Medication[]) => {
   const dayKey = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
   const today = new Date().getDay();
@@ -26,16 +64,27 @@ export const getUserData = async (saveUser: (user: string) => void, saveMeds: (m
   }
 }
 
-const Dashboard = ({ user, setUser, meds, setMeds }: UserDataProps) => {
+const Dashboard = ({ user, setUser, meds, setMeds, setHistory, events, setEvents }: MedHistoryProps) => {
+  const displayDate = new Date().toLocaleDateString(
+    'en-US',
+    {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    }
+  );
+
   useEffect(() => {
     getUserData(setUser, setMeds);
-  }, [setUser, setMeds]);
+    getMedHistory(setHistory, setEvents, events);
+  }, [setUser, setMeds, setHistory, setEvents, events]);
 
   return (
     <>
       <Navbar />
-      <section className='max-w-md mx-auto p-8'>
-        <h1 className='font-bold mb-8 text-cyan-400 text-center text-xl'>{user}'s Medications</h1>
+      <section className='max-w-2xl mx-auto p-8'>
+        <h1 className='font-bold mb-8 text-cyan-400 text-center text-xl'>{user}'s Medications for {displayDate}</h1>
         <MedicationList meds={getMedsDue(meds)} setMeds={setMeds} />
       </section>
     </>

--- a/src/pages/MedicationHistory.tsx
+++ b/src/pages/MedicationHistory.tsx
@@ -1,0 +1,20 @@
+import Navbar from "../components/Navbar";
+import { HistoryData } from '../types';
+import Calendar from '../components/Calendar';
+
+const MedicationHistory = ({ user, events }: HistoryData) => {
+
+  return (
+    <>
+      <Navbar />
+      <section className='max-w-3xl mx-auto'>
+        <h1 className='font-bold my-8 text-cyan-400 text-center text-xl'>{user}'s History</h1>
+        <Calendar
+          events={events}
+        />
+      </section>
+    </>
+  );
+};
+
+export default MedicationHistory;

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -13,7 +13,7 @@ const Profile = ({ user, setUser, meds, setMeds }: UserDataProps) => {
   return (
     <>
       <Navbar />
-      <section className='max-w-lg mx-auto p-8'>
+      <section className='max-w-lg mx-auto py-8'>
         <h1 className='font-bold mb-8 text-cyan-400 text-center text-xl'>{user}'s Profile</h1>
         <MedicationForm meds={meds} setMeds={setMeds} />
         <MasterMedList meds={meds} setMeds={setMeds} />

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,32 @@
+import { EventInput } from '@fullcalendar/react';
+
+export interface HistoryData {
+  user: string;
+  events: EventInput[];
+}
+
+export interface CalendarData {
+  events: EventInput[];
+}
+
+// export interface CalendarEvents extends MedHistoryProps {
+//   // events: EventInput[];
+//   // setEvents: (evtInput: EventInput[]) => void;
+//   getMedHistory: (
+//     setHistory: (medHistory: History[]) => void,
+//     setUser: (user: string) => void,
+//     setEvents: (evtInput: EventInput[]) => void,
+//     events: EventInput[]
+//   ) => void;
+// }
+
+export interface MedHistoryProps extends UserDataProps {
+  history: History[];
+  setHistory: (medHistory: History[]) => void;
+  events: EventInput[];
+  setEvents: (evtInput: EventInput[]) => void;
+}
+
 export interface UserDataProps extends MasterMedListProps {
   user: string;
   setUser: (user: string) => void;
@@ -21,7 +50,7 @@ export interface Medication {
   user: string;
 }
 
-interface History {
+export interface History {
   _id: string;
   dateDue: Date;
   medsDue: Medication[];


### PR DESCRIPTION
Currently only works with normal flow through application (login > dashboard > history).
Refreshing page on history or profile, as well as initially visiting the app on either of those endpoints causes the calendar to lose events.
Current status of calendar is view only. May keep it this way as simply a means of viewing prior medication administration, but add a way to focus on specific dates/times/meds on click.